### PR TITLE
Pally amendments

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '20.15.1'
  
       - name: Install dependencies
-        run: npm ci
+        run: npm install
  
       - name: Install pa11y
         run: npm install -g pa11y-ci

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,5 +1,6 @@
 {
     "urls": [
-        
+        "https://5chmbvngab.eu-west-1.awsapprunner.com",
+        "https://5chmbvngab.eu-west-1.awsapprunner.com/loginForm"
     ]
 }


### PR DESCRIPTION
Updated pa11y, issues with doing a clean install ('npm ci') as opposed to 'npm install' due to a conflict between the package and package-lock files. URLs were also added to the .pa11yci file.